### PR TITLE
Fix locale for japanese

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -14,5 +14,17 @@
   "browserActionTitle": {
     "message": "slack emoji meister",
     "description": "The title of the browser action button"
+  },
+  "contextMenuTitle": {
+    "message": "add slack emoji",
+    "description": "The title of context menu"
+  },
+  "promptTeamName": {
+    "message": "Give your slack team name.",
+    "description": "The slack team name of prompt message"
+  },
+  "promptEmojiName": {
+    "message": "Give your emoji a name.",
+    "description": "The slack emoji name of prompt message"
   }
 }

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -14,5 +14,17 @@
   "browserActionTitle": {
     "message": "slack emoji meister",
     "description": "The title of the browser action button"
+  },
+  "contextMenuTitle": {
+    "message": "画像をSlackの絵文字に追加",
+    "description": "The title of context menu"
+  },
+  "promptTeamName": {
+    "message": "Slackチーム名を入力してください",
+    "description": "The slack team name of prompt message"
+  },
+  "promptEmojiName": {
+    "message": "絵文字名を入力してください",
+    "description": "The slack emoji name of prompt message"
   }
 }

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1,0 +1,18 @@
+{
+  "appName": {
+    "message": "slack emoji meister",
+    "description": "The name of the application"
+  },
+  "appShortName": {
+    "message": "slack emoji",
+    "description": "The short_name (maximum of 12 characters recommended) is a short version of the app's name."
+  },
+  "appDescription": {
+    "message": "Slackの絵文字を簡単に追加できます",
+    "description": "The description of the application"
+  },
+  "browserActionTitle": {
+    "message": "slack emoji meister",
+    "description": "The title of the browser action button"
+  }
+}

--- a/app/scripts/background.ts
+++ b/app/scripts/background.ts
@@ -10,8 +10,8 @@ import {
 const onClickContextMenus = async (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
   if( !info.srcUrl ) return;
   const image_url = info.srcUrl;
-  const team_name = prompt("Give your slack team name.") || '';
-  const emoji_name = prompt("Give your emoji a name.") || '';
+  const team_name = prompt(chrome.i18n.getMessage('promptTeamName')) || '';
+  const emoji_name = prompt(chrome.i18n.getMessage('promptEmojiName')) || '';
   const session_info = await getSessionInfo(team_name)
   if(!session_info) return openLoginForm(team_name)
   await uploadEmoji(team_name, emoji_name , image_url, session_info)
@@ -20,7 +20,7 @@ const onClickContextMenus = async (info: chrome.contextMenus.OnClickData, tab: c
 chrome.runtime.onInstalled.addListener((details) => {
   console.log('previousVersion', details.previousVersion);
   chrome.contextMenus.create({
-    title: 'add slack emoji',
+    title: chrome.i18n.getMessage('contextMenuTitle'),
     contexts: ['image'],
     onclick: onClickContextMenus
   });


### PR DESCRIPTION
Fixes #7

- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

---

1. Add messages.json for Japanese. e6afa92
2. Use chrome.i18n.getMessage for context menu and prompt messages. 224d3c9
